### PR TITLE
Add support for python3.10 - removing `loop` parameter

### DIFF
--- a/aiomanhole/__init__.py
+++ b/aiomanhole/__init__.py
@@ -62,52 +62,45 @@ class InteractiveInterpreter:
     def attempt_compile(self, line):
         return self.compiler(line)
 
-    @asyncio.coroutine
-    def send_exception(self):
+    async def send_exception(self):
         """When an exception has occurred, write the traceback to the user."""
         self.compiler.reset()
 
         exc = traceback.format_exc()
         self.writer.write(exc.encode('utf8'))
 
-        yield from self.writer.drain()
+        await self.writer.drain()
 
-    @asyncio.coroutine
-    def attempt_exec(self, codeobj, namespace):
+    async def attempt_exec(self, codeobj, namespace):
         with contextlib.redirect_stdout(StringIO()) as buf:
-            value = yield from self._real_exec(codeobj, namespace)
+            value = await self._real_exec(codeobj, namespace)
 
         return value, buf.getvalue()
 
-    @asyncio.coroutine
-    def _real_exec(self, codeobj, namespace):
-        yield  # quick hack to pretend to be a coroutine, which attempt_exec expects
+    async def _real_exec(self, codeobj, namespace):
         return eval(codeobj, namespace)
 
-    @asyncio.coroutine
-    def handle_one_command(self):
+    async def handle_one_command(self):
         """Process a single command. May have many lines."""
 
         while True:
-            yield from self.write_prompt()
-            codeobj = yield from self.read_command()
+            await self.write_prompt()
+            codeobj = await self.read_command()
 
             if codeobj is not None:
-                yield from self.run_command(codeobj)
+                await self.run_command(codeobj)
 
-    @asyncio.coroutine
-    def run_command(self, codeobj):
+    async def run_command(self, codeobj):
         """Execute a compiled code object, and write the output back to the client."""
         try:
-            value, stdout = yield from self.attempt_exec(codeobj, self.namespace)
+            value, stdout = await self.attempt_exec(codeobj, self.namespace)
         except Exception:
-            yield from self.send_exception()
+            await self.send_exception()
             return
         else:
-            yield from self.send_output(value, stdout)
+            await self.send_output(value, stdout)
 
-    @asyncio.coroutine
-    def write_prompt(self):
+    async def write_prompt(self):
         writer = self.writer
 
         if self.compiler.is_partial_command():
@@ -115,10 +108,9 @@ class InteractiveInterpreter:
         else:
             writer.write(sys.ps1.encode('utf8'))
 
-        yield from writer.drain()
+        await writer.drain()
 
-    @asyncio.coroutine
-    def read_command(self):
+    async def read_command(self):
         """Read a command from the user line by line.
 
         Returns a code object suitable for execution.
@@ -126,7 +118,7 @@ class InteractiveInterpreter:
 
         reader = self.reader
 
-        line = yield from reader.readline()
+        line = await reader.readline()
         if line == b'':  # lost connection
             raise ConnectionResetError()
 
@@ -134,13 +126,12 @@ class InteractiveInterpreter:
             # skip the newline to make CommandCompiler work as advertised
             codeobj = self.attempt_compile(line.rstrip(b'\n'))
         except SyntaxError:
-            yield from self.send_exception()
+            await self.send_exception()
             return
 
         return codeobj
 
-    @asyncio.coroutine
-    def send_output(self, value, stdout):
+    async def send_output(self, value, stdout):
         """Write the output or value of the expression back to user.
 
         >>> 5
@@ -157,7 +148,7 @@ class InteractiveInterpreter:
         if stdout:
             writer.write(stdout.encode('utf8'))
 
-        yield from writer.drain()
+        await writer.drain()
 
     def _setup_prompts(self):
         try:
@@ -169,8 +160,7 @@ class InteractiveInterpreter:
         except AttributeError:
             sys.ps2 = "... "
 
-    @asyncio.coroutine
-    def __call__(self, reader, writer):
+    async def __call__(self, reader, writer):
         """Main entry point for an interpreter session with a single client."""
 
         self.reader = reader
@@ -180,11 +170,11 @@ class InteractiveInterpreter:
 
         if self.banner:
             writer.write(self.banner)
-            yield from writer.drain()
+            await writer.drain()
 
         while True:
             try:
-                yield from self.handle_one_command()
+                await self.handle_one_command()
             except ConnectionResetError:
                 writer.close()
                 break
@@ -207,12 +197,11 @@ class ThreadedInteractiveInterpreter(InteractiveInterpreter):
         super().__init__(*args, **kwargs)
         self.command_timeout = command_timeout
 
-    @asyncio.coroutine
-    def _real_exec(self, codeobj, namespace):
+    async def _real_exec(self, codeobj, namespace):
         task = self.loop.run_in_executor(None, eval, codeobj, namespace)
         if self.command_timeout:
-            task = asyncio.wait_for(task, self.command_timeout, loop=self.loop)
-        value = yield from task
+            task = asyncio.wait_for(task, self.command_timeout)
+        value = await task
         return value
 
 
@@ -278,17 +267,19 @@ def start_manhole(banner=None, host='127.0.0.1', port=None, path=None,
 
     if path:
         f = asyncio.ensure_future(
-            asyncio.start_unix_server(client_cb, path=path, loop=loop), loop=loop)
+            asyncio.start_unix_server(client_cb, path=path), loop=loop)
         coros.append(f)
 
     if port is not None:
         f = asyncio.ensure_future(asyncio.start_server(
-            client_cb, host=host, port=port, loop=loop), loop=loop)
+            client_cb, host=host, port=port), loop=loop)
         coros.append(f)
 
-    return asyncio.gather(*coros, loop=loop)
+    return asyncio.gather(*coros)
 
 
 if __name__ == '__main__':
-    start_manhole(path='/var/tmp/testing.manhole', banner='Well this is neat\n', threaded=True, shared=True)
-    asyncio.get_event_loop().run_forever()
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    start_manhole(path='/var/tmp/testing.manhole', banner='Well this is neat\n', threaded=True, shared=True, loop = loop)
+    loop.run_forever()

--- a/setup.py
+++ b/setup.py
@@ -6,33 +6,35 @@ import sys
 from setuptools import setup
 
 # Publish Helper.
-if sys.argv[-1] == 'publish':
-    os.system('python3 setup.py sdist upload')
+if sys.argv[-1] == "publish":
+    os.system("python3 setup.py sdist upload")
     sys.exit()
 
 settings = {
-    'name': 'aiomanhole',
-    'version': '0.6.0',
-    'description': "Python module to provide a manhole in asyncio applications",
-    'long_description': '\n\n'.join([open('README.rst').read(), open('CHANGELOG.rst').read()]),
-    'author': 'Nathan Hoad',
-    'author_email': 'nathan@getoffmalawn.com',
-    'url': 'https://github.com/nathan-hoad/aiomanhole',
-    'license': 'BSD (3-clause)',
-    'classifiers': [
+    "name": "aiomanhole",
+    "version": "0.6.0",
+    "description": "Python module to provide a manhole in asyncio applications",
+    "long_description": "\n\n".join(
+        [open("README.rst").read(), open("CHANGELOG.rst").read()]
+    ),
+    "author": "Nathan Hoad",
+    "author_email": "nathan@getoffmalawn.com",
+    "url": "https://github.com/nathan-hoad/aiomanhole",
+    "license": "BSD (3-clause)",
+    "classifiers": [
         # 'Development Status :: 5 - Production/Stable',
-        'Intended Audience :: Developers',
-        'Natural Language :: English',
-        'License :: OSI Approved :: BSD License',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: 3.10',
+        "Intended Audience :: Developers",
+        "Natural Language :: English",
+        "License :: OSI Approved :: BSD License",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.10",
     ],
-    'packages': ['aiomanhole']
+    "packages": ["aiomanhole"],
 }
 
 setup(**settings)

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,9 @@ settings = {
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.10',
     ],
     'packages': ['aiomanhole']
 }

--- a/test_aiomanhole.py
+++ b/test_aiomanhole.py
@@ -12,25 +12,26 @@ import pytest
 from aiomanhole import StatefulCommandCompiler, InteractiveInterpreter, start_manhole
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope="function")
 def compiler():
     return StatefulCommandCompiler()
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope="function")
 def interpreter(loop):
-    s = InteractiveInterpreter({}, '', loop)
+    s = InteractiveInterpreter({}, "", loop)
     s.reader = MockStream()
     s.writer = MockStream()
 
     return s
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope="function")
 def loop():
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(None)
     return loop
+
 
 @contextmanager
 def tcp_server(loop):
@@ -38,18 +39,21 @@ def tcp_server(loop):
     (socket,) = server.sockets
     (ip, port) = socket.getsockname()
 
-    yield loop.run_until_complete(asyncio.open_connection('127.0.0.1', port))
+    yield loop.run_until_complete(asyncio.open_connection("127.0.0.1", port))
 
     server.close()
     loop.run_until_complete(server.wait_closed())
+
 
 @contextmanager
 def unix_server(loop):
     directory = tempfile.mkdtemp()
 
     try:
-        domain_socket = os.path.join(directory, 'aiomanhole')
-        (server,) = loop.run_until_complete(start_manhole(path=domain_socket, loop=loop))
+        domain_socket = os.path.join(directory, "aiomanhole")
+        (server,) = loop.run_until_complete(
+            start_manhole(path=domain_socket, loop=loop)
+        )
 
         yield loop.run_until_complete(asyncio.open_unix_connection(path=domain_socket))
 
@@ -62,16 +66,16 @@ def unix_server(loop):
 
 async def send_command(message, reader, writer, loop):
     # Prompt on connect
-    assert await reader.read(4) == b'>>> '
+    assert await reader.read(4) == b">>> "
 
     # Send message
     writer.write(message)
 
     # Read until we see the next prompt, then strip off the prompt
-    prompt = b'\n>>>'
+    prompt = b"\n>>>"
     response = await reader.readuntil(separator=prompt)
     writer.close()
-    return response[:-len(prompt)]
+    return response[: -len(prompt)]
 
 
 class MockStream:
@@ -91,74 +95,77 @@ class MockStream:
 
 class TestStatefulCommandCompiler:
     def test_one_line(self, compiler):
-        f = compiler(b'f = 5')
+        f = compiler(b"f = 5")
         assert f is not None
         ns = {}
         eval(f, ns)
-        assert ns['f'] == 5
+        assert ns["f"] == 5
 
-        f = compiler(b'5')
+        f = compiler(b"5")
         assert f is not None
         eval(f, {})
 
-        assert __builtins__['_'] == 5
+        assert __builtins__["_"] == 5
 
-        assert compiler(b'import asyncio') is not None
+        assert compiler(b"import asyncio") is not None
 
     MULTI_LINE_1 = [
-        b'try:',
-        b'    raise Exception',
-        b'except:',
-        b'    pass',
-        b'',
+        b"try:",
+        b"    raise Exception",
+        b"except:",
+        b"    pass",
+        b"",
     ]
 
     MULTI_LINE_2 = [
-        b'for i in range(2):',
-        b'    pass',
-        b'',
+        b"for i in range(2):",
+        b"    pass",
+        b"",
     ]
 
     MULTI_LINE_3 = [
-        b'while False:',
-        b'    pass',
-        b'',
+        b"while False:",
+        b"    pass",
+        b"",
     ]
 
     MULTI_LINE_4 = [
-        b'class Foo:',
-        b'    pass',
-        b'',
+        b"class Foo:",
+        b"    pass",
+        b"",
     ]
 
     MULTI_LINE_5 = [
-        b'def foo():',
-        b'    pass',
-        b'',
+        b"def foo():",
+        b"    pass",
+        b"",
     ]
 
     MULTI_LINE_6 = [
-        b'if False:',
-        b'    pass',
-        b'',
+        b"if False:",
+        b"    pass",
+        b"",
     ]
 
     MULTI_LINE_7 = [
-        b'@decorated',
-        b'def foo():',
-        b'    pass',
-        b'',
+        b"@decorated",
+        b"def foo():",
+        b"    pass",
+        b"",
     ]
 
-    @pytest.mark.parametrize('input', [
-        MULTI_LINE_1,
-        MULTI_LINE_2,
-        MULTI_LINE_4,
-        MULTI_LINE_4,
-        MULTI_LINE_5,
-        MULTI_LINE_6,
-        MULTI_LINE_7,
-    ])
+    @pytest.mark.parametrize(
+        "input",
+        [
+            MULTI_LINE_1,
+            MULTI_LINE_2,
+            MULTI_LINE_4,
+            MULTI_LINE_4,
+            MULTI_LINE_5,
+            MULTI_LINE_6,
+            MULTI_LINE_7,
+        ],
+    )
     def test_multi_line(self, compiler, input):
         for line in input[:-1]:
             assert compiler(line) is None
@@ -169,9 +176,9 @@ class TestStatefulCommandCompiler:
 
     def test_multi_line__fails_on_missing_line_ending(self, compiler):
         lines = [
-            b'@decorated',
-            b'def foo():',
-            b'    pass',
+            b"@decorated",
+            b"def foo():",
+            b"    pass",
         ]
         for line in lines[:-1]:
             assert compiler(line) is None
@@ -182,31 +189,41 @@ class TestStatefulCommandCompiler:
 
 
 class TestInteractiveInterpreter:
-    @pytest.mark.parametrize('banner,expected_result', [
-        (b'straight up bytes', b'straight up bytes'),
-        ('dat unicode tho', b'dat unicode tho'),
-        (None, b''),
-        (object(), ValueError),
-    ])
+    @pytest.mark.parametrize(
+        "banner,expected_result",
+        [
+            (b"straight up bytes", b"straight up bytes"),
+            ("dat unicode tho", b"dat unicode tho"),
+            (None, b""),
+            (object(), ValueError),
+        ],
+    )
     def test_get_banner(self, banner, expected_result, interpreter):
         if isinstance(expected_result, type) and issubclass(expected_result, Exception):
             pytest.raises(expected_result, interpreter.get_banner, banner)
         else:
             assert interpreter.get_banner(banner) == expected_result
 
-    @pytest.mark.parametrize('partial', [True, False])
+    @pytest.mark.parametrize("partial", [True, False])
     def test_write_prompt(self, interpreter, loop, partial):
-        with mock.patch.object(interpreter.compiler, 'is_partial_command', return_value=partial):
-            with mock.patch('sys.ps1', '>>> ', create=True), mock.patch('sys.ps2', '... ', create=True):
+        with mock.patch.object(
+            interpreter.compiler, "is_partial_command", return_value=partial
+        ):
+            with mock.patch("sys.ps1", ">>> ", create=True), mock.patch(
+                "sys.ps2", "... ", create=True
+            ):
                 loop.run_until_complete(interpreter.write_prompt())
 
-        expected_value = b'... ' if partial else b'>>> '
+        expected_value = b"... " if partial else b">>> "
         assert interpreter.writer.buf.getvalue() == expected_value
 
-    @pytest.mark.parametrize('line,partial', [
-        (b'f = 5', False),
-        (b'def foo():', True),
-    ])
+    @pytest.mark.parametrize(
+        "line,partial",
+        [
+            (b"f = 5", False),
+            (b"def foo():", True),
+        ],
+    )
     def test_read_command(self, interpreter, loop, line, partial):
         interpreter.reader.write(line)
         f = loop.run_until_complete(interpreter.read_command())
@@ -217,25 +234,37 @@ class TestInteractiveInterpreter:
             assert f is not None
 
     def test_read_command__raises_on_empty_read(self, interpreter, loop):
-        pytest.raises(ConnectionResetError, loop.run_until_complete, interpreter.read_command())
+        pytest.raises(
+            ConnectionResetError, loop.run_until_complete, interpreter.read_command()
+        )
 
-    @pytest.mark.parametrize('value,stdout,expected_output', [
-        (5, '', b'5\n'),
-        (5, 'hello', b'5\nhello'),
-        (None, 'hello', b'hello'),
-    ])
+    @pytest.mark.parametrize(
+        "value,stdout,expected_output",
+        [
+            (5, "", b"5\n"),
+            (5, "hello", b"5\nhello"),
+            (None, "hello", b"hello"),
+        ],
+    )
     def test_send_output(self, interpreter, loop, value, stdout, expected_output):
         loop.run_until_complete(interpreter.send_output(value, stdout))
 
         output = interpreter.writer.buf.getvalue()
         assert output == expected_output
 
-    @pytest.mark.parametrize('stdin,expected_output', [
-        (b'print("hello")', b'hello'),
-        (b'101', b'101'),
-    ])
-    @pytest.mark.parametrize('server_factory', [tcp_server, unix_server])
-    def test_command_over_localhost_network(self, loop, server_factory, stdin, expected_output):
+    @pytest.mark.parametrize(
+        "stdin,expected_output",
+        [
+            (b'print("hello")', b"hello"),
+            (b"101", b"101"),
+        ],
+    )
+    @pytest.mark.parametrize("server_factory", [tcp_server, unix_server])
+    def test_command_over_localhost_network(
+        self, loop, server_factory, stdin, expected_output
+    ):
         with server_factory(loop=loop) as (reader, writer):
-            output = loop.run_until_complete(send_command(stdin + b'\n', reader, writer, loop))
+            output = loop.run_until_complete(
+                send_command(stdin + b"\n", reader, writer, loop)
+            )
             assert output == expected_output

--- a/test_aiomanhole.py
+++ b/test_aiomanhole.py
@@ -38,7 +38,7 @@ def tcp_server(loop):
     (socket,) = server.sockets
     (ip, port) = socket.getsockname()
 
-    yield loop.run_until_complete(asyncio.open_connection('127.0.0.1', port, loop=loop))
+    yield loop.run_until_complete(asyncio.open_connection('127.0.0.1', port))
 
     server.close()
     loop.run_until_complete(server.wait_closed())
@@ -51,7 +51,7 @@ def unix_server(loop):
         domain_socket = os.path.join(directory, 'aiomanhole')
         (server,) = loop.run_until_complete(start_manhole(path=domain_socket, loop=loop))
 
-        yield loop.run_until_complete(asyncio.open_unix_connection(path=domain_socket, loop=loop))
+        yield loop.run_until_complete(asyncio.open_unix_connection(path=domain_socket))
 
         server.close()
         loop.run_until_complete(server.wait_closed())
@@ -81,14 +81,10 @@ class MockStream:
     def write(self, data):
         self.buf.write(data)
 
-    @asyncio.coroutine
-    def drain(self):
-        yield
+    async def drain(self):
         pass
 
-    @asyncio.coroutine
-    def readline(self):
-        yield
+    async def readline(self):
         self.buf.seek(0)
         return self.buf.readline()
 


### PR DESCRIPTION
Hello, 

As of python 3.10. `loop` argument for most of the functions was remove (see https://docs.python.org/3/whatsnew/3.10.html#whatsnew310-removed)
Also I took the liberty and reformated the code with black, hope that's ok